### PR TITLE
Corrected broken translate route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   get 'translate' => 'translate#index', :as => :translate_list
-  post 'translate' => 'translate#translate', :as => :translate
+  post 'translate/translate' => 'translate#translate', :as => :translate
   get 'translate/reload' => 'translate#reload', :as => :translate_reload
 end


### PR DESCRIPTION
Hi,

Thanks for updating this great gem, so that it works w/ Rails 3.

FWIW, I just tried it w/ my rails 3.0 app (ruby 1.9.2) and the translate#translate route didn't work.

Unfortunately the use of /translate for both translate/index and translate/translate was conflated ...and confusing. Despite attempting to tie them to different HTTP verbs (post & get) the translate#translate action never got called.

(I know because I after clicking the "Save Translation" button, walked the request in the debugger.)

I hope you'll accept this update and push a new gem.

Cheers,
Jonathan
